### PR TITLE
[TI-774] - Fixing CVE's for fed-2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "debug": "^2.1.2",
     "jspath": "^0.3.1",
     "lodash": "^4.17.10",
-    "machinepack-http": "^6.0.1",
+    "machinepack-http": "^7.0.3",
     "mustache": "^2.1.3",
     "pipeworks": "^1.3.0"
   },


### PR DESCRIPTION
**Ticket:** crowdflower.atlassian.net/browse/TI-774

**Description:** The original bagpipes repository hasn't been updated in a year so in order to fix the CVE's found in Requestor Proxy, I decided to fork this library and manually bump the outdated packages, in this case the only package that needs to be upgraded was `machinepack-http` that had a dependency on an old version of `lodash`, I upgrade it to `7.0.3` because based on the commit history it looks like the introduced changes were added to only address some vulnerabilities and it doesn't introduce any breaking changes